### PR TITLE
Feat/kepler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set initial time to 8 a.m. March 14th 2724 CE
 - Extra planets (there are now 8 in the star system)
 
+### Changed
+
+- Introduced Kepler orbital equations for better, more accurate orbit simulations
+
 ### Fixed
 
 - Prevent division by zero in magnetic ship-planet pull effect by preventing execution at > 1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Current time display in HUD
 - Set initial time to 8 a.m. March 14th 2724 CE
 - Extra planets (there are now 8 in the star system)
+- Mass component used in orbital calculations
 
 ### Changed
 
 - Introduced Kepler orbital equations for better, more accurate orbit simulations
+
+### Removed
+
+- Orbiting bodies will no longer orbit origin (they require an Orbitable with Mass)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set initial time to 8 a.m. March 14th 2724 CE
 - Extra planets (there are now 8 in the star system)
 
+### Fixed
+
+- Prevent division by zero in magnetic ship-planet pull effect by preventing execution at > 1.0
+
 ## [0.0.14] - 2023-10-11
 
 ### Added

--- a/src/player/dynamic_orbit.rs
+++ b/src/player/dynamic_orbit.rs
@@ -26,7 +26,7 @@ pub fn dynamic_orbital_positioning_system(
     let player_translation = transform.translation.xy();
 
     if let Some((pos, _entity)) = tree.nearest_neighbour(player_translation) {
-        if pos.distance(player_translation) < 1500. {
+        if pos.distance(player_translation) > 1. && pos.distance(player_translation) < 1500. {
             impulse.impulse += (pos - player_translation).normalize() * 2000.;
         }
     }

--- a/src/world/astronomy/orbit.rs
+++ b/src/world/astronomy/orbit.rs
@@ -116,7 +116,13 @@ fn period(semi_major_axis: f32, parent_mass: f32) -> f32 {
 }
 
 fn mean_motion(period: f32) -> f32 {
-    TAU / period
+    // TODO: Sign (+|-) should be configurable per system for clockwise (+)
+    //       or counterclockwise (-) motion.
+    //       Eventually, planets should **rarely** be able to flip it themselves.
+    //       Small objects like comets and asteroids should be able to orbit the other
+    //       way regardless of the system bias (so flipping it should maybe be a
+    //       probability value determined by the mass of the body).
+    -(TAU / period)
 }
 
 fn mean_anomaly(mean_motion: f32, initial_mean_anomaly: f32, time: f32) -> f32 {

--- a/src/world/astronomy/orbit.rs
+++ b/src/world/astronomy/orbit.rs
@@ -1,16 +1,30 @@
+use std::f32::consts::{PI, TAU};
+
 use bevy::prelude::*;
 
 use crate::core::resources::{game_time::GameTime, state::GameState};
 
-pub const ORBITAL_PERIOD_SCALING_FACTOR: f32 = 1.0;
+pub const GRAVITATIONAL_CONSTANT: f32 = 6.67430e-11; // https://en.wikipedia.org/wiki/Gravitational_constant#Modern_value
+pub const ORBITAL_PERIOD_SCALING_FACTOR: f32 = 1.0e-15;
 
 #[derive(Component, Clone, Debug)]
 pub struct Orbit {
     pub parent: Option<Entity>,
-    pub semi_major_axis: f32,
-    // pub eccentricity: f32,
-    // pub argument_of_periapsis: f32,
-    // pub initial_mean_anomaly: f32,
+    pub semi_major_axis: f32,       // Meters
+    pub eccentricity: f32,          // Circular: 0., Elliptic: < 1., Parabolic: 1., Hyperbolic: > 1.
+    pub argument_of_periapsis: f32, // Radians
+    pub initial_mean_anomaly: f32,  // Radians
+}
+impl Default for Orbit {
+    fn default() -> Self {
+        Self {
+            parent: None,
+            semi_major_axis: 0.,
+            eccentricity: 0.,
+            argument_of_periapsis: 0.,
+            initial_mean_anomaly: 0.,
+        }
+    }
 }
 
 #[derive(Component, Clone, Debug)]
@@ -53,16 +67,16 @@ pub fn orbital_positioning_system(
             };
         }
 
-        transform.translation.x = entity_translation.x
-            + (game_time.elapsed_secs() / orbit.semi_major_axis.sqrt()
-                * ORBITAL_PERIOD_SCALING_FACTOR)
-                .cos()
-                * orbit.semi_major_axis;
-        transform.translation.y = entity_translation.y
-            + (game_time.elapsed_secs() / orbit.semi_major_axis.sqrt()
-                * ORBITAL_PERIOD_SCALING_FACTOR)
-                .sin()
-                * orbit.semi_major_axis;
+        let pos = position_at_time(
+            orbit.semi_major_axis,
+            orbit.eccentricity,
+            orbit.argument_of_periapsis,
+            orbit.initial_mean_anomaly,
+            // TODO: Set mass on parent Orbitable component
+            1.989e30 * ORBITAL_PERIOD_SCALING_FACTOR, // parent_mass.mass,
+            game_time.elapsed_secs(),
+        );
+        transform.translation = entity_translation + Vec3::from(pos);
     }
 }
 
@@ -70,4 +84,80 @@ pub fn orbitable_update_system(mut orbitables: Query<(&mut Orbitable, &Transform
     for (mut orbitable, transform) in orbitables.iter_mut() {
         orbitable.0 = transform.translation;
     }
+}
+
+/* Math */
+
+fn position_at_time(
+    semi_major_axis: f32,
+    eccentricity: f32,
+    argument_of_periapsis: f32,
+    initial_mean_anomaly: f32,
+    parent_mass: f32,
+    time: f32,
+) -> (f32, f32, f32) {
+    let period = period(semi_major_axis, parent_mass);
+    let mean_motion = mean_motion(period);
+    let mean_anomaly = mean_anomaly(mean_motion, initial_mean_anomaly, time);
+    let eccentric_anomaly = eccentric_anomaly(eccentricity, mean_anomaly);
+    let true_anomaly = true_anomaly(eccentricity, eccentric_anomaly);
+    let heliocentric_distance = heliocentric_distance(semi_major_axis, eccentricity, true_anomaly);
+
+    position(
+        true_anomaly,
+        heliocentric_distance,
+        argument_of_periapsis,
+        mean_anomaly,
+    )
+}
+
+fn period(semi_major_axis: f32, parent_mass: f32) -> f32 {
+    TAU * (semi_major_axis.powi(3) / (GRAVITATIONAL_CONSTANT * parent_mass)).sqrt()
+}
+
+fn mean_motion(period: f32) -> f32 {
+    TAU / period
+}
+
+fn mean_anomaly(mean_motion: f32, initial_mean_anomaly: f32, time: f32) -> f32 {
+    (initial_mean_anomaly + mean_motion * time).rem_euclid(TAU)
+}
+
+fn eccentric_anomaly(eccentricity: f32, mean_anomaly: f32) -> f32 {
+    let e = eccentricity;
+    let ma = mean_anomaly;
+    let mut ea = ma;
+    // Uses Newton's method to estimate the eccentric anomaly
+    for _i in 0..5 {
+        ea = ea - (ea - e * ea.sin() - ma) / (1.0 - e * ea.cos());
+    }
+    ea
+}
+
+fn true_anomaly(eccentricity: f32, eccentric_anomaly: f32) -> f32 {
+    let e = eccentricity;
+    let e_a = eccentric_anomaly;
+    2.0 * (((1.0 + e) / (1.0 - e) * ((e_a / 2.0).tan()).powi(2)).sqrt()).atan()
+}
+
+fn heliocentric_distance(semi_major_axis: f32, eccentricity: f32, true_anomaly: f32) -> f32 {
+    let semilatus_rectum = semi_major_axis * (1.0 - eccentricity.powi(2));
+    semilatus_rectum / (1.0 + eccentricity * true_anomaly.cos())
+}
+
+fn position(
+    true_anomaly: f32,
+    heliocentric_distance: f32,
+    argument_of_periapsis: f32,
+    mean_anomaly: f32,
+) -> (f32, f32, f32) {
+    let ymod = if (mean_anomaly % TAU) < PI { -1.0 } else { 1.0 };
+
+    let x = heliocentric_distance * true_anomaly.cos();
+    let y = heliocentric_distance * true_anomaly.sin() * ymod;
+
+    let rotated_x = x * argument_of_periapsis.cos() - y * argument_of_periapsis.sin();
+    let rotated_y = x * argument_of_periapsis.sin() + y * argument_of_periapsis.cos();
+
+    (rotated_x, rotated_y, 0.)
 }

--- a/src/world/astronomy/orbit.rs
+++ b/src/world/astronomy/orbit.rs
@@ -70,7 +70,7 @@ pub fn orbital_positioning_system(
         if let Some(parent) = orbit.parent {
             let orbitable = orbitables.get(parent);
 
-            let (entity_translation, entity_mass) = match orbitable {
+            let (parent_translation, parent_mass) = match orbitable {
                 Ok((orb, mass)) => (orb.0, mass.0),
                 Err(_) => (Vec3::ZERO, 0.),
             };
@@ -80,11 +80,10 @@ pub fn orbital_positioning_system(
                 orbit.eccentricity,
                 orbit.argument_of_periapsis,
                 orbit.initial_mean_anomaly,
-                // TODO: Set mass on parent Orbitable component
-                entity_mass * ORBITAL_PERIOD_SCALING_FACTOR, // parent_mass.mass,
+                parent_mass * ORBITAL_PERIOD_SCALING_FACTOR,
                 game_time.elapsed_secs(),
             );
-            transform.translation = entity_translation + Vec3::from(pos);
+            transform.translation = parent_translation + Vec3::from(pos);
         }
     }
 }

--- a/src/world/astronomy/planet.rs
+++ b/src/world/astronomy/planet.rs
@@ -36,10 +36,7 @@ impl Default for PlanetBundle {
                 color: Color::ORANGE_RED,
             },
             orbitable: Orbitable::default(),
-            orbit: Orbit {
-                parent: None,
-                semi_major_axis: 0.,
-            },
+            orbit: Orbit::default(),
             animation_bundle: AnimationBundle {
                 indices: PLANET_ANIMATION_INDICES,
                 timer: AnimationTimer(Timer::from_seconds(0.1, TimerMode::Repeating)),

--- a/src/world/astronomy/planet.rs
+++ b/src/world/astronomy/planet.rs
@@ -6,7 +6,7 @@ use crate::{
     world::spatial::KDNode,
 };
 
-use super::orbit::{Orbit, Orbitable};
+use super::orbit::{Mass, Orbit, Orbitable};
 
 const PLANET_ANIMATION_INDICES: AnimationIndices = AnimationIndices {
     first: 0,
@@ -26,6 +26,7 @@ pub struct PlanetBundle {
     pub animation_bundle: AnimationBundle,
     pub sprite_sheet_bundle: SpriteSheetBundle,
     pub kd_node: KDNode,
+    pub mass: Mass,
 }
 impl Default for PlanetBundle {
     fn default() -> Self {
@@ -43,6 +44,7 @@ impl Default for PlanetBundle {
             },
             sprite_sheet_bundle: SpriteSheetBundle::default(),
             kd_node: KDNode,
+            mass: Mass(5.972e24), // 1 Earth
         }
     }
 }

--- a/src/world/astronomy/planetary_system.rs
+++ b/src/world/astronomy/planetary_system.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 use super::{
-    orbit::{Orbit, OrbitPlugin},
+    orbit::{Mass, Orbit, OrbitPlugin},
     planet::PlanetBundle,
     star::{Star, StarBundle},
 };
@@ -60,6 +60,7 @@ fn spawn_planets(
                 transform: Transform::from_scale(Vec3::splat(2.0)), // Divide by parent scale?
                 ..default()
             },
+            mass: Mass(5.9722e24),
             ..default()
         },
         EarthLike,

--- a/src/world/astronomy/planetary_system.rs
+++ b/src/world/astronomy/planetary_system.rs
@@ -50,6 +50,9 @@ fn spawn_planets(
             orbit: Orbit {
                 parent: Some(star_query.single()),
                 semi_major_axis: 20000.0,
+                eccentricity: 0.0167086,
+                argument_of_periapsis: f32::to_radians(288.1),
+                initial_mean_anomaly: f32::to_radians(0.),
             },
             sprite_sheet_bundle: SpriteSheetBundle {
                 texture_atlas: sprites.planet.clone(),
@@ -72,6 +75,7 @@ fn spawn_planets(
             orbit: Orbit {
                 parent: Some(star_query.single()),
                 semi_major_axis: *radius,
+                ..default()
             },
             sprite_sheet_bundle: SpriteSheetBundle {
                 texture_atlas: sprites.noatmos.clone(),
@@ -101,6 +105,7 @@ fn spawn_demo_orbital(
         Orbit {
             parent: planet_query.iter().min(),
             semi_major_axis: 250.0,
+            ..default()
         },
         Name::new("Demo Orbital"),
     ));

--- a/src/world/astronomy/star.rs
+++ b/src/world/astronomy/star.rs
@@ -7,7 +7,7 @@ use crate::{
     world::spatial::KDNode,
 };
 
-use super::orbit::Orbitable;
+use super::orbit::{Mass, Orbitable};
 
 const STAR_ANIMATION_INDICES: AnimationIndices = AnimationIndices {
     first: 0,
@@ -26,6 +26,7 @@ pub struct StarBundle {
     pub animation_bundle: AnimationBundle,
     pub sprite_sheet_bundle: SpriteSheetBundle,
     pub kd_node: KDNode,
+    pub mass: Mass,
 }
 impl Default for StarBundle {
     fn default() -> Self {
@@ -42,6 +43,7 @@ impl Default for StarBundle {
             },
             sprite_sheet_bundle: SpriteSheetBundle::default(),
             kd_node: KDNode,
+            mass: Mass(1.989e30), // 1 Sol
         }
     }
 }


### PR DESCRIPTION
closes #28, closes #48 

_Partially based on https://github.com/atbentley/bevy_mod_orbits/ with some needed modifications. Most notably: Z values are now Y values, as we're dealing exclusively in the 2-dimensional domain._

By submitting this pull request, you agree to follow our Code of Conduct: https://github.com/thombruce/.github/blob/main/CODE_OF_CONDUCT.md

---

_Internal use. Do not delete._

- [ ] Tests passing
- [ ] Coverage sufficient
- [ ] Manual review
- [ ] No A11y regression
- [ ] Translations provided or not needed
